### PR TITLE
Return response interface because sometimes we use header of the response

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Mastodon.fetchAccessToken(clientId, clientSecret, code, BASE_URL)
 ## Get timeline
 
 ```typescript
-import Mastodon, { Status } from 'megalodon'
+import Mastodon, { Status, Response } from 'megalodon'
 
 const BASE_URL: string = 'https://friends.nico'
 
@@ -70,15 +70,15 @@ const client = new Mastodon(
 )
 
 client.get<[Status]>('/timelines/home')
-  .then((resp: [Status]) => {
-    console.log(resp)
+  .then((resp: Response<[Status]>) => {
+    console.log(resp.data)
   })
 ```
 
 ## Post toot
 
 ```typescript
-import Mastodon, { Status } from 'megalodon'
+import Mastodon, { Status, Response } from 'megalodon'
 
 const BASE_URL: string = 'https://friends.nico'
 
@@ -94,8 +94,8 @@ const client = new Mastodon(
 client.post<Status>('/statuses', {
   status: toot
 })
-  .then((res: Status) => {
-    console.log(res)
+  .then((res: Response<Status>) => {
+    console.log(res.data)
   })
 
 ```

--- a/example/javascript/favourite.js
+++ b/example/javascript/favourite.js
@@ -1,6 +1,6 @@
 const Mastodon = require( '../../lib/mastodon')
 
-const BASE_URL = 'https://mastodon.social'
+const BASE_URL = 'https://mstdn.jp'
 
 const access_token = '...'
 
@@ -9,5 +9,8 @@ const client = new Mastodon(
   BASE_URL + '/api/v1'
 )
 
-client.get('/timelines/home')
-  .then(res => console.log(res.headers))
+client.get('/favourites')
+  .then((res) => {
+    console.log(res.headers)
+    console.log(res.data)
+  })

--- a/example/javascript/timeline.js
+++ b/example/javascript/timeline.js
@@ -10,4 +10,4 @@ const client = new Mastodon(
 )
 
 client.get('/timelines/home')
-  .then(res => console.log(res.headers))
+  .then(res => console.log(res.data))

--- a/example/typescript/favourite.ts
+++ b/example/typescript/favourite.ts
@@ -1,0 +1,16 @@
+import Mastodon, { Status, Response } from 'megalodon'
+
+const BASE_URL: string = 'https://mstdn.jp'
+
+const access_token: string = '...'
+
+const client = new Mastodon(
+  access_token,
+  BASE_URL + '/api/v1'
+)
+
+client.get<[Status]>('/favourites')
+  .then((res: Response<[Status]>) => {
+    console.log(res.headers)
+    console.log(res.data)
+  })

--- a/example/typescript/timeline.ts
+++ b/example/typescript/timeline.ts
@@ -1,4 +1,4 @@
-import Mastodon, { Status } from 'megalodon'
+import Mastodon, { Status, Response } from 'megalodon'
 
 const BASE_URL: string = 'https://mastodon.social'
 
@@ -10,6 +10,6 @@ const client = new Mastodon(
 )
 
 client.get<[Status]>('/timelines/home')
-  .then((resp: [Status]) => {
-    console.log(resp)
+  .then((resp: Response<[Status]>) => {
+    console.log(resp.data)
   })

--- a/example/typescript/toot.ts
+++ b/example/typescript/toot.ts
@@ -1,5 +1,5 @@
 import * as readline from 'readline'
-import Mastodon, { Status } from 'megalodon'
+import Mastodon, { Status, Response } from 'megalodon'
 
 const rl: readline.ReadLine = readline.createInterface({
   input: process.stdin,
@@ -19,7 +19,7 @@ new Promise(resolve => {
     client.post<Status>('/statuses', {
       status: status
     })
-      .then((res: Status) => {
+      .then((res: Response<Status>) => {
         console.log(res)
         rl.close()
         resolve(res)

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,9 @@ import Notification from './entities/notification'
 import Status from './entities/status'
 import Tag from './entities/tag'
 import StreamListener from './stream_listener'
+import Response from './response'
 
-export { Application, Mention, Notification, Status, Tag, StreamListener }
+export { Application, Mention, Notification, Status, Tag, StreamListener, Response }
 
 export default Mastodon
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,4 +10,3 @@ import Response from './response'
 export { Application, Mention, Notification, Status, Tag, StreamListener, Response }
 
 export default Mastodon
-

--- a/src/mastodon.ts
+++ b/src/mastodon.ts
@@ -1,9 +1,10 @@
 import { OAuth2 } from 'oauth'
-import axios from 'axios'
+import axios, { AxiosResponse } from 'axios'
 
 import StreamListener from './stream_listener'
-
 import OAuth from './oauth'
+import Response from './response'
+
 const NO_REDIRECT = 'urn:ietf:wg:oauth:2.0:oob'
 const DEFAULT_URL = 'https://mastodon.social'
 const DEFAULT_SCOPE = 'read write follow'
@@ -176,15 +177,23 @@ export default class Mastodon {
    * @param path relative path from baseUrl
    * @param params Query parameters
    */
-  public get<T>(path: string, params = {}): Promise<T> {
+  public get<T>(path: string, params = {}): Promise<Response<T>> {
     return axios
-      .get(this.baseUrl + path, {
+      .get<T>(this.baseUrl + path, {
         headers: {
           'Authorization': `Bearer ${this.accessToken}`
         },
         params
       })
-      .then(resp => resp.data as T)
+      .then((resp: AxiosResponse<T>) => {
+        const res: Response<T> = {
+          data: resp.data,
+          status: resp.status,
+          statusText: resp.statusText,
+          headers: resp.headers
+        }
+        return res
+      })
   }
 
   /**
@@ -192,14 +201,22 @@ export default class Mastodon {
    * @param path relative path from baseUrl
    * @param params Form data. If you want to post file, please use FormData()
    */
-  public patch<T>(path: string, params = {}): Promise<T> {
+  public patch<T>(path: string, params = {}): Promise<Response<T>> {
     return axios
-      .patch(this.baseUrl + path, params, {
+      .patch<T>(this.baseUrl + path, params, {
         headers: {
           'Authorization': `Bearer ${this.accessToken}`
         }
       })
-      .then(resp => resp.data as T)
+      .then((resp: AxiosResponse<T>) => {
+        const res: Response<T> = {
+          data: resp.data,
+          status: resp.status,
+          statusText: resp.statusText,
+          headers: resp.headers
+        }
+        return res
+      })
   }
 
   /**
@@ -207,28 +224,44 @@ export default class Mastodon {
    * @param path relative path from baseUrl
    * @param params Form data
    */
-  public post<T>(path: string, params = {}): Promise<T> {
+  public post<T>(path: string, params = {}): Promise<Response<T>> {
     return axios
-      .post(this.baseUrl + path, params, {
+      .post<T>(this.baseUrl + path, params, {
         headers: {
           'Authorization': `Bearer ${this.accessToken}`
         }
       })
-      .then(resp => resp.data as T)
+      .then((resp: AxiosResponse<T>) => {
+        const res: Response<T> = {
+          data: resp.data,
+          status: resp.status,
+          statusText: resp.statusText,
+          headers: resp.headers
+        }
+        return res
+      })
   }
 
   /**
    * DELETE request to mastodon REST API.
    * @param path relative path from baseUrl
    */
-  public del(path: string): Promise<{}> {
+  public del(path: string): Promise<Response<{}>> {
     return axios
       .delete(this.baseUrl + path, {
         headers: {
           'Authorization': `Bearer ${this.accessToken}`
         }
       })
-      .then(resp => resp.data as {})
+      .then((resp: AxiosResponse) => {
+        const res: Response<{}> = {
+          data: resp.data as {},
+          status: resp.status,
+          statusText: resp.statusText,
+          headers: resp.headers
+        }
+        return res
+      })
   }
 
   /**

--- a/src/mastodon.ts
+++ b/src/mastodon.ts
@@ -32,28 +32,6 @@ export default class Mastodon {
   }
 
   /**
-   * Unauthorized GET request to mastodon REST API.
-   * @param path relative path from baseUrl
-   * @param params Query parameters
-   * @param baseUrl base URL of the target
-   */
-  public static get(path: string, params = {}, baseUrl = DEFAULT_URL): Promise<object> {
-    const apiUrl = baseUrl
-    return axios
-      .get(apiUrl + path, {
-        params
-      })
-      .then(resp => resp.data)
-  }
-
-  private static _post(path: string, params = {}, baseUrl = DEFAULT_URL): Promise<object> {
-    const apiUrl = baseUrl
-    return axios
-      .post(apiUrl + path, params)
-      .then(resp => resp.data)
-  }
-
-  /**
    * First, call createApp to get client_id and client_secret.
    * Next, call generateAuthUrl to get authorization url.
    * @param client_name Form Data, which is sent to /api/v1/apps
@@ -80,7 +58,6 @@ export default class Mastodon {
           })
       })
   }
-
 
   /**
    * Create an application
@@ -170,6 +147,28 @@ export default class Mastodon {
       redirect_uri,
       grant_type: 'authorization_code'
     }, baseUrl).then(data => OAuth.TokenData.from(data as OAuth.TokenDataFromServer))
+  }
+
+  /**
+   * Unauthorized GET request to mastodon REST API.
+   * @param path relative path from baseUrl
+   * @param params Query parameters
+   * @param baseUrl base URL of the target
+   */
+  public static get(path: string, params = {}, baseUrl = DEFAULT_URL): Promise<object> {
+    const apiUrl = baseUrl
+    return axios
+      .get(apiUrl + path, {
+        params
+      })
+      .then(resp => resp.data)
+  }
+
+  private static _post(path: string, params = {}, baseUrl = DEFAULT_URL): Promise<object> {
+    const apiUrl = baseUrl
+    return axios
+      .post(apiUrl + path, params)
+      .then(resp => resp.data)
   }
 
   /**

--- a/src/response.ts
+++ b/src/response.ts
@@ -1,0 +1,6 @@
+export default interface Response<T = any> {
+  data: T,
+  status: number,
+  statusText: string,
+  headers: any
+}

--- a/tslint.json
+++ b/tslint.json
@@ -8,6 +8,9 @@
     "variable-name": [
       true,
       "ban-keywords"
+    ],
+    "space-before-function-paren": [
+      "never"
     ]
   },
   "rulesDirectory": []


### PR DESCRIPTION
I want to use header of the response, because the next id which is used in favourite API, is in link header.
So, I changed some responses to return own response interface.