### PR TITLE
Export Account

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import Mastodon from './mastodon'
+import Account from './entities/account'
 import Application from './entities/application'
 import Mention from './entities/mention'
 import Notification from './entities/notification'
@@ -9,6 +10,6 @@ import WebSocket from './web_socket'
 import Response from './response'
 import OAuth from './oauth'
 
-export { Application, Mention, Notification, Status, Tag, StreamListener, WebSocket, Response, OAuth }
+export { Account, Application, Mention, Notification, Status, Tag, StreamListener, WebSocket, Response, OAuth }
 
 export default Mastodon


### PR DESCRIPTION
```import { Account } from 'megalodon'``` is better than ```import Account from 'megalodon/lib/entities/account'```

Used in  ```client.get<Account>('/accounts/verify_credentials')```