### PR TITLE
Clear all listeners and close the connection before reconnect

### DIFF
--- a/example/typescript/proxy_instance.ts
+++ b/example/typescript/proxy_instance.ts
@@ -4,7 +4,7 @@ declare var process: {
   env: {
     PROXY_HOST: string
     PROXY_PORT: number
-    PROXY_PROTOCOL: string
+    PROXY_PROTOCOL: 'http' | 'https' | 'socks4' | 'socks4a' | 'socks5' | 'socks5h' | 'socks'
   }
 }
 

--- a/example/typescript/proxy_streaming.ts
+++ b/example/typescript/proxy_streaming.ts
@@ -5,7 +5,7 @@ declare var process: {
     MASTODON_ACCESS_TOKEN: string
     PROXY_HOST: string
     PROXY_PORT: number
-    PROXY_PROTOCOL: string
+    PROXY_PROTOCOL: 'http' | 'https' | 'socks4' | 'socks4a' | 'socks5' | 'socks5h' | 'socks'
   }
 }
 

--- a/example/typescript/proxy_timeline.ts
+++ b/example/typescript/proxy_timeline.ts
@@ -5,7 +5,7 @@ declare var process: {
     MASTODON_ACCESS_TOKEN: string
     PROXY_HOST: string
     PROXY_PORT: number
-    PROXY_PROTOCOL: string
+    PROXY_PROTOCOL: 'http' | 'https' | 'socks4' | 'socks4a' | 'socks5' | 'socks5h' | 'socks'
   }
 }
 

--- a/example/typescript/proxy_web_socket.ts
+++ b/example/typescript/proxy_web_socket.ts
@@ -7,7 +7,7 @@ declare var process: {
     MASTODON_ACCESS_TOKEN: string
     PROXY_HOST: string
     PROXY_PORT: number
-    PROXY_PROTOCOL: string
+    PROXY_PROTOCOL: 'http' | 'https' | 'socks4' | 'socks4a' | 'socks5' | 'socks5h' | 'socks'
   }
 }
 

--- a/example/typescript/web_socket.ts
+++ b/example/typescript/web_socket.ts
@@ -27,7 +27,7 @@ stream.on('pong', () => {
 })
 
 stream.on('update', (status: Status) => {
-  logger.debug(status)
+  logger.debug(status.url)
 })
 
 stream.on('notification', (notification: Notification) => {

--- a/src/web_socket.ts
+++ b/src/web_socket.ts
@@ -110,10 +110,15 @@ export default class WebSocket extends EventEmitter {
       setTimeout(() => {
         if (this._reconnectCurrentAttempts < this._reconnectMaxAttempts) {
           this._reconnectCurrentAttempts++
+          this._clearBinding()
+          if (this._client) {
+            // In reconnect, we want to close the connection immediately,
+            // because recoonect is necessary when some problems occur.
+            this._client.terminate()
+          }
           // Call connect methods
           console.log('Reconnecting')
           this._client = this._connect(this.url, this.stream, this._accessToken, this.headers, this.proxyConfig)
-          this._clearBinding()
           this._bindSocket(this._client)
         }
       }, this._reconnectInterval)


### PR DESCRIPTION
Now clear all listeners after create a connection, but it is not expected.
We have to clear all listeners before create a new connection in reconnect, otherwise the client receives duplicated events.