### PR TITLE
Fix register interface for scopes

### DIFF
--- a/example/javascript/authorization.js
+++ b/example/javascript/authorization.js
@@ -6,7 +6,7 @@ const rl = readline.createInterface({
   output: process.stdout
 })
 
-const SCOPES = 'read write follow'
+const SCOPES = ['read', 'write', 'follow']
 const BASE_URL = 'https://mastodon.social'
 
 let clientId

--- a/example/typescript/authorization.ts
+++ b/example/typescript/authorization.ts
@@ -6,7 +6,7 @@ const rl: readline.ReadLine = readline.createInterface({
   output: process.stdout
 })
 
-const SCOPES: string = 'read write follow'
+const SCOPES: Array<string> = ['read', 'write', 'follow']
 const BASE_URL: string = 'https://mastodon.social'
 
 let clientId: string

--- a/src/default.ts
+++ b/src/default.ts
@@ -1,3 +1,3 @@
 export const NO_REDIRECT = 'urn:ietf:wg:oauth:2.0:oob'
-export const DEFAULT_SCOPE = 'read write follow'
+export const DEFAULT_SCOPE = ['read', 'write', 'follow']
 export const DEFAULT_UA = 'megalodon'

--- a/src/mastodon.ts
+++ b/src/mastodon.ts
@@ -43,15 +43,15 @@ export default class Mastodon implements MegalodonInterface {
 
   public async registerApp(
     client_name: string,
-    options: Partial<{ scopes: string; redirect_uris: string; website: string }> = {
+    options: Partial<{ scopes: Array<string>; redirect_uris: string; website: string }> = {
       scopes: DEFAULT_SCOPE,
       redirect_uris: NO_REDIRECT
     }
   ): Promise<OAuth.AppData> {
     return this.createApp(client_name, options).then(async appData => {
       return this.generateAuthUrl(appData.client_id, appData.client_secret, {
-        redirect_uri: appData.redirect_uri,
-        scope: options.scopes
+        scope: options.scopes,
+        redirect_uri: appData.redirect_uri
       }).then(url => {
         appData.url = url
         return appData
@@ -68,7 +68,7 @@ export default class Mastodon implements MegalodonInterface {
    */
   public async createApp(
     client_name: string,
-    options: Partial<{ redirect_uris: string; scopes: string; website: string }> = {
+    options: Partial<{ scopes: Array<string>; redirect_uris: string; website: string }> = {
       redirect_uris: NO_REDIRECT,
       scopes: DEFAULT_SCOPE
     }
@@ -82,9 +82,9 @@ export default class Mastodon implements MegalodonInterface {
       scopes: string
       website?: string
     } = {
-      client_name,
-      redirect_uris,
-      scopes
+      client_name: client_name,
+      redirect_uris: redirect_uris,
+      scopes: scopes.join(' ')
     }
     if (options.website) params.website = options.website
 
@@ -103,7 +103,7 @@ export default class Mastodon implements MegalodonInterface {
   public generateAuthUrl(
     clientId: string,
     clientSecret: string,
-    options: Partial<{ redirect_uri: string; scope: string }> = {
+    options: Partial<{ scope: Array<string>; redirect_uri: string }> = {
       redirect_uri: NO_REDIRECT,
       scope: DEFAULT_SCOPE
     }
@@ -114,7 +114,7 @@ export default class Mastodon implements MegalodonInterface {
         redirect_uri: options.redirect_uri,
         response_type: 'code',
         client_id: clientId,
-        scope: options.scope
+        scope: options.scope!.join(',')
       })
       resolve(url)
     })

--- a/src/megalodon.ts
+++ b/src/megalodon.ts
@@ -21,7 +21,10 @@ export interface MegalodonInterface {
    * @param client_name Form Data, which is sent to /api/v1/apps
    * @param options Form Data, which is sent to /api/v1/apps. and properties should be **snake_case**
    */
-  registerApp(client_name: string, options: Partial<{ scopes: string; redirect_uris: string; website: string }>): Promise<OAuth.AppData>
+  registerApp(
+    client_name: string,
+    options: Partial<{ scopes: Array<string>; redirect_uris: string; website: string }>
+  ): Promise<OAuth.AppData>
 
   /**
    * Call /api/v1/apps
@@ -30,16 +33,10 @@ export interface MegalodonInterface {
    * @param client_name your application's name
    * @param options Form Data
    */
-  createApp(client_name: string, options: Partial<{ redirect_uris: string; scopes: string; website: string }>): Promise<OAuth.AppData>
-
-  /**
-   * Generate authorization url using OAuth2.
-   *
-   * @param clientId your OAuth app's client ID
-   * @param clientSecret your OAuth app's client Secret
-   * @param options as property, redirect_uri and scope are available, and must be the same as when you register your app
-   */
-  generateAuthUrl(clientId: string, clientSecret: string, options: Partial<{ redirect_uri: string; scope: string }>): Promise<string>
+  createApp(
+    client_name: string,
+    options: Partial<{ scopes: Array<string>; redirect_uris: string; website: string }>
+  ): Promise<OAuth.AppData>
 
   // ======================================
   // apps


### PR DESCRIPTION
**Breaking Changes**
I changed scope format, `string` to `Array<string`. You may provide `'read write follow'` as scope up until this point, but after this change you have to provide `['read', 'write', 'follow']` as scope.