### PR TITLE
refs #714 Don't call getHeaders of FormData when platform is browser

### DIFF
--- a/src/mastodon.ts
+++ b/src/mastodon.ts
@@ -1285,7 +1285,11 @@ export default class Mastodon implements MegalodonInterface {
         formData.append('focus', options.focus)
       }
     }
-    return this.client.post<MastodonAPI.Entity.Attachment>('/api/v1/media', formData, formData.getHeaders()).then(res => {
+    let headers: { [key: string]: string } = {}
+    if (typeof formData.getHeaders === 'function') {
+      headers = formData.getHeaders()
+    }
+    return this.client.post<MastodonAPI.Entity.Attachment>('/api/v1/media', formData, headers).then(res => {
       return Object.assign(res, {
         data: MastodonAPI.Converter.attachment(res.data)
       })
@@ -1312,7 +1316,11 @@ export default class Mastodon implements MegalodonInterface {
         formData.append('focus', options.focus)
       }
     }
-    return this.client.put<MastodonAPI.Entity.Attachment>(`/api/v1/media/${id}`, formData, formData.getHeaders()).then(res => {
+    let headers: { [key: string]: string } = {}
+    if (typeof formData.getHeaders === 'function') {
+      headers = formData.getHeaders()
+    }
+    return this.client.put<MastodonAPI.Entity.Attachment>(`/api/v1/media/${id}`, formData, headers).then(res => {
       return Object.assign(res, {
         data: MastodonAPI.Converter.attachment(res.data)
       })

--- a/src/misskey.ts
+++ b/src/misskey.ts
@@ -1255,8 +1255,12 @@ export default class Misskey implements MegalodonInterface {
   public async uploadMedia(file: any, _options?: { description?: string; focus?: string }): Promise<Response<Entity.Attachment>> {
     const formData = new FormData()
     formData.append('file', file)
+    let headers: { [key: string]: string } = {}
+    if (typeof formData.getHeaders === 'function') {
+      headers = formData.getHeaders()
+    }
     return this.client
-      .post<MisskeyAPI.Entity.File>('/api/drive/files/create', formData, formData.getHeaders())
+      .post<MisskeyAPI.Entity.File>('/api/drive/files/create', formData, headers)
       .then(res => ({ ...res, data: MisskeyAPI.Converter.file(res.data) }))
   }
 

--- a/src/pleroma.ts
+++ b/src/pleroma.ts
@@ -1292,7 +1292,11 @@ export default class Pleroma implements MegalodonInterface {
         formData.append('focus', options.focus)
       }
     }
-    return this.client.post<PleromaAPI.Entity.Attachment>('/api/v1/media', formData, formData.getHeaders()).then(res => {
+    let headers: { [key: string]: string } = {}
+    if (typeof formData.getHeaders === 'function') {
+      headers = formData.getHeaders()
+    }
+    return this.client.post<PleromaAPI.Entity.Attachment>('/api/v1/media', formData, headers).then(res => {
       return Object.assign(res, {
         data: PleromaAPI.Converter.attachment(res.data)
       })
@@ -1319,7 +1323,11 @@ export default class Pleroma implements MegalodonInterface {
         formData.append('focus', options.focus)
       }
     }
-    return this.client.put<PleromaAPI.Entity.Attachment>(`/api/v1/media/${id}`, formData, formData.getHeaders()).then(res => {
+    let headers: { [key: string]: string } = {}
+    if (typeof formData.getHeaders === 'function') {
+      headers = formData.getHeaders()
+    }
+    return this.client.put<PleromaAPI.Entity.Attachment>(`/api/v1/media/${id}`, formData, headers).then(res => {
       return Object.assign(res, {
         data: PleromaAPI.Converter.attachment(res.data)
       })


### PR DESCRIPTION
Because getHeaders method is only implemented on nodejs.
And it is not required to post media.

refs #714 