### PR TITLE
fix: Decode received data to string in websocket message

### DIFF
--- a/megalodon/src/mastodon/web_socket.ts
+++ b/megalodon/src/mastodon/web_socket.ts
@@ -198,7 +198,7 @@ export default class WebSocket extends EventEmitter implements WebSocketInterfac
    * @param client A WebSocket instance.
    */
   private _bindSocket(client: WS) {
-    client.on('close', (code: number, _reason: string) => {
+    client.on('close', (code: number, _reason: Buffer) => {
       // Refer the code: https://tools.ietf.org/html/rfc6455#section-7.4
       if (code === 1000) {
         this.emit('close', {})
@@ -224,8 +224,8 @@ export default class WebSocket extends EventEmitter implements WebSocketInterfac
         client.ping('')
       }, 10000)
     })
-    client.on('message', (data: WS.Data) => {
-      this.parser.parse(data)
+    client.on('message', (data: WS.Data, isBinary: boolean) => {
+      this.parser.parse(data, isBinary)
     })
     client.on('error', (err: Error) => {
       this.emit('error', err)
@@ -288,7 +288,8 @@ export class Parser extends EventEmitter {
   /**
    * @param message Message body of websocket.
    */
-  public parse(message: WS.Data) {
+  public parse(data: WS.Data, isBinary: boolean) {
+    const message = isBinary ? data : data.toString()
     if (typeof message !== 'string') {
       this.emit('heartbeat', {})
       return

--- a/megalodon/src/misskey/web_socket.ts
+++ b/megalodon/src/misskey/web_socket.ts
@@ -244,7 +244,7 @@ export default class WebSocket extends EventEmitter implements WebSocketInterfac
    * @param client A WebSocket instance.
    */
   private _bindSocket(client: WS) {
-    client.on('close', (code: number, _reason: string) => {
+    client.on('close', (code: number, _reason: Buffer) => {
       if (code === 1000) {
         this.emit('close', {})
       } else {
@@ -269,8 +269,8 @@ export default class WebSocket extends EventEmitter implements WebSocketInterfac
         client.ping('')
       }, 10000)
     })
-    client.on('message', (data: WS.Data) => {
-      this.parser.parse(data, this._channelID)
+    client.on('message', (data: WS.Data, isBinary: boolean) => {
+      this.parser.parse(data, isBinary, this._channelID)
     })
     client.on('error', (err: Error) => {
       this.emit('error', err)
@@ -328,7 +328,8 @@ export class Parser extends EventEmitter {
    * @param message Message body of websocket.
    * @param channelID Parse only messages which has same channelID.
    */
-  public parse(message: WS.Data, channelID: string) {
+  public parse(data: WS.Data, isBinary: boolean, channelID: string) {
+    const message = isBinary ? data : data.toString()
     if (typeof message !== 'string') {
       this.emit('heartbeat', {})
       return

--- a/megalodon/src/pleroma/web_socket.ts
+++ b/megalodon/src/pleroma/web_socket.ts
@@ -199,7 +199,7 @@ export default class WebSocket extends EventEmitter implements WebSocketInterfac
    * @param client A WebSocket instance.
    */
   private _bindSocket(client: WS) {
-    client.on('close', (code: number, _reason: string) => {
+    client.on('close', (code: number, _reason: Buffer) => {
       // Refer the code: https://tools.ietf.org/html/rfc6455#section-7.4
       if (code === 1000) {
         this.emit('close', {})
@@ -225,8 +225,8 @@ export default class WebSocket extends EventEmitter implements WebSocketInterfac
         client.ping('')
       }, 10000)
     })
-    client.on('message', (data: WS.Data) => {
-      this.parser.parse(data)
+    client.on('message', (data: WS.Data, isBinary: boolean) => {
+      this.parser.parse(data, isBinary)
     })
     client.on('error', (err: Error) => {
       this.emit('error', err)
@@ -289,7 +289,8 @@ export class Parser extends EventEmitter {
   /**
    * @param message Message body of websocket.
    */
-  public parse(message: WS.Data) {
+  public parse(data: WS.Data, isBinary: boolean) {
+    const message = isBinary ? data : data.toString()
     if (typeof message !== 'string') {
       this.emit('heartbeat', {})
       return

--- a/megalodon/test/unit/webo_socket.spec.ts
+++ b/megalodon/test/unit/webo_socket.spec.ts
@@ -88,7 +88,7 @@ describe('Parser', () => {
         it('should be called', () => {
           const spy = jest.fn()
           parser.once('heartbeat', spy)
-          parser.parse(message)
+          parser.parse(message, true)
           expect(spy).toHaveBeenCalledWith({})
         })
       })
@@ -98,7 +98,7 @@ describe('Parser', () => {
         it('should be called', () => {
           const spy = jest.fn()
           parser.once('heartbeat', spy)
-          parser.parse(message)
+          parser.parse(Buffer.from(message), false)
           expect(spy).toHaveBeenCalledWith({})
         })
       })
@@ -114,7 +114,7 @@ describe('Parser', () => {
         it('should be called', () => {
           const spy = jest.fn()
           parser.once('delete', spy)
-          parser.parse(message)
+          parser.parse(Buffer.from(message), false)
           expect(spy).toHaveBeenCalledWith('12asdf34')
         })
       })
@@ -129,7 +129,7 @@ describe('Parser', () => {
           const deleted = jest.fn()
           parser.once('error', error)
           parser.once('delete', deleted)
-          parser.parse(message)
+          parser.parse(Buffer.from(message), false)
           expect(error).toHaveBeenCalled()
           expect(deleted).not.toHaveBeenCalled()
         })
@@ -145,7 +145,7 @@ describe('Parser', () => {
         it('should be called', () => {
           const spy = jest.fn()
           parser.once('update', spy)
-          parser.parse(message)
+          parser.parse(Buffer.from(message), false)
           expect(spy).toHaveBeenCalledWith(status)
         })
       })
@@ -158,7 +158,7 @@ describe('Parser', () => {
         it('should be called', () => {
           const spy = jest.fn()
           parser.once('notification', spy)
-          parser.parse(message)
+          parser.parse(Buffer.from(message), false)
           expect(spy).toHaveBeenCalledWith(notification)
         })
       })
@@ -171,7 +171,7 @@ describe('Parser', () => {
         it('should be called', () => {
           const spy = jest.fn()
           parser.once('conversation', spy)
-          parser.parse(message)
+          parser.parse(Buffer.from(message), false)
           expect(spy).toHaveBeenCalledWith(conversation)
         })
       })


### PR DESCRIPTION
Refs: https://github.com/websockets/ws/releases/tag/8.0.0

> Text messages and close reasons are no longer decoded to strings. They are
passed as Buffers to the listeners of their respective events. The listeners
of the 'message' event now take a boolean argument specifying whether or not
the message is binary (e173423).