### PR TITLE
Remove User-Agent header from REST API requests

### DIFF
--- a/megalodon/src/mastodon/api_client.ts
+++ b/megalodon/src/mastodon/api_client.ts
@@ -78,12 +78,7 @@ namespace MastodonAPI {
     ): Promise<Response<T>> {
       let options: AxiosRequestConfig = {
         params: params,
-        headers: Object.assign(
-          {
-            'User-Agent': this.userAgent
-          },
-          headers
-        ),
+        headers: headers,
         maxContentLength: Infinity,
         maxBodyLength: Infinity
       }
@@ -128,12 +123,7 @@ namespace MastodonAPI {
      */
     public async put<T>(path: string, params = {}, headers: { [key: string]: string } = {}): Promise<Response<T>> {
       let options: AxiosRequestConfig = {
-        headers: Object.assign(
-          {
-            'User-Agent': this.userAgent
-          },
-          headers
-        ),
+        headers: headers,
         maxContentLength: Infinity,
         maxBodyLength: Infinity
       }
@@ -178,12 +168,7 @@ namespace MastodonAPI {
      */
     public async putForm<T>(path: string, params = {}, headers: { [key: string]: string } = {}): Promise<Response<T>> {
       let options: AxiosRequestConfig = {
-        headers: Object.assign(
-          {
-            'User-Agent': this.userAgent
-          },
-          headers
-        ),
+        headers: headers,
         maxContentLength: Infinity,
         maxBodyLength: Infinity
       }
@@ -228,12 +213,7 @@ namespace MastodonAPI {
      */
     public async patch<T>(path: string, params = {}, headers: { [key: string]: string } = {}): Promise<Response<T>> {
       let options: AxiosRequestConfig = {
-        headers: Object.assign(
-          {
-            'User-Agent': this.userAgent
-          },
-          headers
-        ),
+        headers: headers,
         maxContentLength: Infinity,
         maxBodyLength: Infinity
       }
@@ -278,12 +258,7 @@ namespace MastodonAPI {
      */
     public async patchForm<T>(path: string, params = {}, headers: { [key: string]: string } = {}): Promise<Response<T>> {
       let options: AxiosRequestConfig = {
-        headers: Object.assign(
-          {
-            'User-Agent': this.userAgent
-          },
-          headers
-        ),
+        headers: headers,
         maxContentLength: Infinity,
         maxBodyLength: Infinity
       }
@@ -328,12 +303,7 @@ namespace MastodonAPI {
      */
     public async post<T>(path: string, params = {}, headers: { [key: string]: string } = {}): Promise<Response<T>> {
       let options: AxiosRequestConfig = {
-        headers: Object.assign(
-          {
-            'User-Agent': this.userAgent
-          },
-          headers
-        ),
+        headers: headers,
         maxContentLength: Infinity,
         maxBodyLength: Infinity
       }
@@ -369,12 +339,7 @@ namespace MastodonAPI {
      */
     public async postForm<T>(path: string, params = {}, headers: { [key: string]: string } = {}): Promise<Response<T>> {
       let options: AxiosRequestConfig = {
-        headers: Object.assign(
-          {
-            'User-Agent': this.userAgent
-          },
-          headers
-        ),
+        headers: headers,
         maxContentLength: Infinity,
         maxBodyLength: Infinity
       }
@@ -411,12 +376,7 @@ namespace MastodonAPI {
     public async del<T>(path: string, params = {}, headers: { [key: string]: string } = {}): Promise<Response<T>> {
       let options: AxiosRequestConfig = {
         data: params,
-        headers: Object.assign(
-          {
-            'User-Agent': this.userAgent
-          },
-          headers
-        ),
+        headers: headers,
         maxContentLength: Infinity,
         maxBodyLength: Infinity
       }

--- a/megalodon/src/misskey/api_client.ts
+++ b/megalodon/src/misskey/api_client.ts
@@ -470,12 +470,7 @@ namespace MisskeyAPI {
      */
     public async post<T>(path: string, params: any = {}, headers: { [key: string]: string } = {}): Promise<Response<T>> {
       let options: AxiosRequestConfig = {
-        headers: Object.assign(
-          {
-            'User-Agent': this.userAgent
-          },
-          headers
-        ),
+        headers: headers,
         maxContentLength: Infinity,
         maxBodyLength: Infinity
       }

--- a/megalodon/src/pleroma/api_client.ts
+++ b/megalodon/src/pleroma/api_client.ts
@@ -303,12 +303,7 @@ namespace PleromaAPI {
     public async get<T>(path: string, params = {}, headers: { [key: string]: string } = {}): Promise<Response<T>> {
       let options: AxiosRequestConfig = {
         params: params,
-        headers: Object.assign(
-          {
-            'User-Agent': this.userAgent
-          },
-          headers
-        )
+        headers: headers
       }
       if (this.accessToken) {
         options = objectAssignDeep({}, options, {
@@ -351,12 +346,7 @@ namespace PleromaAPI {
      */
     public async put<T>(path: string, params = {}, headers: { [key: string]: string } = {}): Promise<Response<T>> {
       let options: AxiosRequestConfig = {
-        headers: Object.assign(
-          {
-            'User-Agent': this.userAgent
-          },
-          headers
-        ),
+        headers: headers,
         maxContentLength: Infinity,
         maxBodyLength: Infinity
       }
@@ -401,12 +391,7 @@ namespace PleromaAPI {
      */
     public async putForm<T>(path: string, params = {}, headers: { [key: string]: string } = {}): Promise<Response<T>> {
       let options: AxiosRequestConfig = {
-        headers: Object.assign(
-          {
-            'User-Agent': this.userAgent
-          },
-          headers
-        ),
+        headers: headers,
         maxContentLength: Infinity,
         maxBodyLength: Infinity
       }
@@ -451,12 +436,7 @@ namespace PleromaAPI {
      */
     public async patch<T>(path: string, params = {}, headers: { [key: string]: string } = {}): Promise<Response<T>> {
       let options: AxiosRequestConfig = {
-        headers: Object.assign(
-          {
-            'User-Agent': this.userAgent
-          },
-          headers
-        ),
+        headers: headers,
         maxContentLength: Infinity,
         maxBodyLength: Infinity
       }
@@ -501,12 +481,7 @@ namespace PleromaAPI {
      */
     public async patchForm<T>(path: string, params = {}, headers: { [key: string]: string } = {}): Promise<Response<T>> {
       let options: AxiosRequestConfig = {
-        headers: Object.assign(
-          {
-            'User-Agent': this.userAgent
-          },
-          headers
-        ),
+        headers: headers,
         maxContentLength: Infinity,
         maxBodyLength: Infinity
       }
@@ -551,12 +526,7 @@ namespace PleromaAPI {
      */
     public async post<T>(path: string, params = {}, headers: { [key: string]: string } = {}): Promise<Response<T>> {
       let options: AxiosRequestConfig = {
-        headers: Object.assign(
-          {
-            'User-Agent': this.userAgent
-          },
-          headers
-        ),
+        headers: headers,
         maxContentLength: Infinity,
         maxBodyLength: Infinity
       }
@@ -592,12 +562,7 @@ namespace PleromaAPI {
      */
     public async postForm<T>(path: string, params = {}, headers: { [key: string]: string } = {}): Promise<Response<T>> {
       let options: AxiosRequestConfig = {
-        headers: Object.assign(
-          {
-            'User-Agent': this.userAgent
-          },
-          headers
-        ),
+        headers: headers,
         maxContentLength: Infinity,
         maxBodyLength: Infinity
       }
@@ -634,12 +599,7 @@ namespace PleromaAPI {
     public async del<T>(path: string, params = {}, headers: { [key: string]: string } = {}): Promise<Response<T>> {
       let options: AxiosRequestConfig = {
         data: params,
-        headers: Object.assign(
-          {
-            'User-Agent': this.userAgent
-          },
-          headers
-        ),
+        headers: headers,
         maxContentLength: Infinity,
         maxBodyLength: Infinity
       }


### PR DESCRIPTION
Because some servers don't allow it by Access-Controll-Allow-Headers