### PR TITLE
fix: misskey detection could fail due to an early axios throw

### DIFF
--- a/megalodon/test/integration/megalodon.spec.ts
+++ b/megalodon/test/integration/megalodon.spec.ts
@@ -24,4 +24,12 @@ describe('detector', () => {
       expect(misskey).toEqual('misskey')
     })
   })
+
+  describe('unknown', () => {
+    const url = 'https://google.com'
+    it('should be null', async () => {
+      const unknown = await detector(url)
+      expect(unknown).toEqual(null)
+    })
+  })
 })


### PR DESCRIPTION
Hi h3poteto,

Thank you for maintaining such a wonderful library. I'm building a tool based on megalodon.

Meanwhile I found that detection on `misskey.io` failed with the `5.4.0` version. Without the try catch block, Axios would throw on attempting to visit `https://misskey.io/api/v1/instance` in the first place. So I added the `try catch` back with a little more explicitness.

Changes (all tests passed):

- `detector` handles sns name detection more thoroughly
- `detector` explicitly returns `null` if no known platform can be detected

Please let me know how you think and if there's anything that I missed or have done incorrectly. Thanks!