### PR TITLE
Add proper quote posts to Pleroma

### DIFF
--- a/megalodon/src/entities/status.ts
+++ b/megalodon/src/entities/status.ts
@@ -39,7 +39,7 @@ namespace Entity {
     language: string | null
     pinned: boolean | null
     emoji_reactions: Array<Reaction>
-    quote: boolean
+    quote: Entity.Status | null
     bookmarked: boolean
   }
 }

--- a/megalodon/src/friendica/api_client.ts
+++ b/megalodon/src/friendica/api_client.ts
@@ -663,7 +663,7 @@ namespace FriendicaAPI {
       emoji_reactions: [],
       bookmarked: s.bookmarked ? s.bookmarked : false,
       // Now quote is supported only fedibird.com.
-      quote: s.quote !== undefined && s.quote !== null
+      quote: null
     })
     export const status_params = (s: Entity.StatusParams): MegalodonEntity.StatusParams => {
       return {

--- a/megalodon/src/mastodon/api_client.ts
+++ b/megalodon/src/mastodon/api_client.ts
@@ -632,7 +632,7 @@ namespace MastodonAPI {
       emoji_reactions: [],
       bookmarked: s.bookmarked ? s.bookmarked : false,
       // Now quote is supported only fedibird.com.
-      quote: s.quote !== undefined && s.quote !== null
+      quote: s.quote ? status(s.quote) : null,
     })
     export const status_params = (s: Entity.StatusParams): MegalodonEntity.StatusParams => s
     export const status_source = (s: Entity.StatusSource): MegalodonEntity.StatusSource => s

--- a/megalodon/src/misskey/api_client.ts
+++ b/megalodon/src/misskey/api_client.ts
@@ -254,7 +254,7 @@ namespace MisskeyAPI {
         pinned: null,
         emoji_reactions: typeof n.reactions === 'object' ? mapReactions(n.reactions, n.myReaction) : [],
         bookmarked: false,
-        quote: n.renote !== undefined && n.text !== null
+        quote: null
       }
     }
 

--- a/megalodon/src/pleroma/api_client.ts
+++ b/megalodon/src/pleroma/api_client.ts
@@ -328,7 +328,7 @@ namespace PleromaAPI {
       pinned: s.pinned,
       emoji_reactions: Array.isArray(s.pleroma.emoji_reactions) ? s.pleroma.emoji_reactions.map(r => reaction(r)) : [],
       bookmarked: s.bookmarked ? s.bookmarked : false,
-      quote: s.reblog !== null && s.reblog.content !== s.content
+      quote: s.quote ? status(s.quote) : null
     })
     export const status_params = (s: Entity.StatusParams): MegalodonEntity.StatusParams => {
       return {

--- a/megalodon/src/pleroma/entities/status.ts
+++ b/megalodon/src/pleroma/entities/status.ts
@@ -37,6 +37,7 @@ namespace PleromaEntity {
     application: Application | null
     language: string | null
     pinned: boolean | null
+	quote: Status | null
     bookmarked?: boolean
     // Reblogged status contains only local parameter.
     pleroma: {

--- a/megalodon/test/integration/mastodon/api_client.spec.ts
+++ b/megalodon/test/integration/mastodon/api_client.spec.ts
@@ -68,7 +68,7 @@ const status: Entity.Status = {
   pinned: null,
   emoji_reactions: [],
   bookmarked: false,
-  quote: false
+  quote: null
 }
 ;(axios.CancelToken.source as any).mockImplementation(() => {
   return {

--- a/megalodon/test/integration/pleroma.spec.ts
+++ b/megalodon/test/integration/pleroma.spec.ts
@@ -68,7 +68,8 @@ const status: PleromaEntity.Status = {
   bookmarked: false,
   pleroma: {
     local: false
-  }
+  },
+  quote: null
 }
 
 const follow: PleromaEntity.Notification = {

--- a/megalodon/test/unit/parser.spec.ts
+++ b/megalodon/test/unit/parser.spec.ts
@@ -57,7 +57,7 @@ const status: Entity.Status = {
   pinned: null,
   emoji_reactions: [],
   bookmarked: false,
-  quote: false
+  quote: null
 }
 
 const notification: Entity.Notification = {

--- a/megalodon/test/unit/pleroma/api_client.spec.ts
+++ b/megalodon/test/unit/pleroma/api_client.spec.ts
@@ -168,7 +168,8 @@ describe('api_client', () => {
               'text/plain': plainContent
             },
             local: false
-          }
+          },
+		  quote: null,
         }
         const megalodonStatus = PleromaAPI.Converter.status(pleromaStatus)
         expect(megalodonStatus.plain_content).toEqual(plainContent)
@@ -212,7 +213,8 @@ describe('api_client', () => {
           bookmarked: false,
           pleroma: {
             local: false
-          }
+          },
+		  quote: null,
         }
         const megalodonStatus = PleromaAPI.Converter.status(pleromaStatus)
         expect(megalodonStatus.plain_content).toBeNull()

--- a/megalodon/test/unit/webo_socket.spec.ts
+++ b/megalodon/test/unit/webo_socket.spec.ts
@@ -56,7 +56,7 @@ const status: Entity.Status = {
   pinned: null,
   emoji_reactions: [],
   bookmarked: false,
-  quote: false
+  quote: null
 }
 
 const notification: Entity.Notification = {


### PR DESCRIPTION
This pull request adds the ability to see quote posts on Pleroma and Akkoma by properly using the `quote` field returned by the Pleroma API. All tests have passed.

It will also be possible to easily add support for Mastodon and Misskey quotes with a few more lines of code