### PR TITLE
Correctly parse Misskey object emoji format

### DIFF
--- a/megalodon/src/misskey/api_client.ts
+++ b/megalodon/src/misskey/api_client.ts
@@ -280,8 +280,10 @@ namespace MisskeyAPI {
     const mapEmojis = (e: Array<Entity.Emoji> | { [key: string]: string }): Array<MegalodonEntity.Emoji> => {
       if (Array.isArray(e)) {
         return e.map(e => emoji(e))
-      } else {
+      } else if (e) {
         return mapReactionEmojis(e)
+      } else {
+        return [];
       }
     }
 

--- a/megalodon/src/misskey/api_client.ts
+++ b/megalodon/src/misskey/api_client.ts
@@ -90,7 +90,7 @@ namespace MisskeyAPI {
         avatar_static: u.avatarColor,
         header: '',
         header_static: '',
-        emojis: Array.isArray(u.emojis) ? u.emojis.map(e => emoji(e)) : [],
+        emojis: mapEmojis(u.emojis),
         moved: null,
         fields: [],
         bot: null
@@ -119,7 +119,7 @@ namespace MisskeyAPI {
         avatar_static: u.avatarColor,
         header: u.bannerUrl,
         header_static: u.bannerColor,
-        emojis: Array.isArray(u.emojis) ? u.emojis.map(e => emoji(e)) : [],
+        emojis: mapEmojis(u.emojis),
         moved: null,
         fields: [],
         bot: u.isBot
@@ -253,7 +253,7 @@ namespace MisskeyAPI {
           : '',
         plain_content: n.text ? n.text : null,
         created_at: n.createdAt,
-        emojis: (Array.isArray(n.emojis) ? n.emojis.map(e => emoji(e)) : []).concat(mapReactionEmojis(n.reactionEmojis)),
+        emojis: mapEmojis(n.emojis).concat(mapReactionEmojis(n.reactionEmojis)),
         replies_count: n.repliesCount,
         reblogs_count: n.renoteCount,
         favourites_count: 0,
@@ -274,6 +274,14 @@ namespace MisskeyAPI {
         emoji_reactions: typeof n.reactions === 'object' ? mapReactions(n.reactions, n.myReaction) : [],
         bookmarked: false,
         quote: n.renote !== undefined && n.text !== null
+      }
+    }
+
+    const mapEmojis = (e: Array<Entity.Emoji> | { [key: string]: string }): Array<MegalodonEntity.Emoji> => {
+      if (Array.isArray(e)) {
+        return e.map(e => emoji(e))
+      } else {
+        return mapReactionEmojis(e)
       }
     }
 

--- a/megalodon/src/misskey/entities/note.ts
+++ b/megalodon/src/misskey/entities/note.ts
@@ -17,7 +17,7 @@ namespace MisskeyEntity {
     reactions: { [key: string]: number }
     // This field includes only remote emojis
     reactionEmojis: { [key: string]: string }
-    emojis: Array<Emoji>
+    emojis: Array<Emoji> | { [key: string]: string }
     fileIds: Array<string>
     files: Array<File>
     replyId: string | null

--- a/megalodon/src/misskey/entities/user.ts
+++ b/megalodon/src/misskey/entities/user.ts
@@ -8,6 +8,6 @@ namespace MisskeyEntity {
     host: string | null
     avatarUrl: string
     avatarColor: string
-    emojis: Array<Emoji>
+    emojis: Array<Emoji> | { [key: string]: string }
   }
 }

--- a/megalodon/src/misskey/entities/userDetail.ts
+++ b/megalodon/src/misskey/entities/userDetail.ts
@@ -13,7 +13,7 @@ namespace MisskeyEntity {
     isModerator: boolean
     isBot: boolean
     isCat: boolean
-    emojis: Array<Emoji>
+    emojis: Array<Emoji> | { [key: string]: string }
     createdAt: string
     bannerUrl: string
     bannerColor: string

--- a/megalodon/test/unit/misskey/api_client.spec.ts
+++ b/megalodon/test/unit/misskey/api_client.spec.ts
@@ -279,5 +279,99 @@ describe('api_client', () => {
         ])
       })
     })
+    describe('emoji', () => {
+      it('emojis in array format should be parsed', () => {
+        const plainContent = 'hoge\nfuga\nfuga'
+        const note: MisskeyEntity.Note = {
+          id: '1',
+          createdAt: '2021-02-01T01:49:29',
+          userId: '1',
+          user: user,
+          text: plainContent,
+          cw: null,
+          visibility: 'public',
+          renoteCount: 0,
+          repliesCount: 0,
+          reactions: {},
+          reactionEmojis: {},
+          emojis: [
+            {
+              aliases: [],
+              name: ':example1:',
+              url: 'https://example.com/emoji1.png',
+              category: '',
+            },
+            {
+              aliases: [],
+              name: ':example2:',
+              url: 'https://example.com/emoji2.png',
+              category: '',
+            },
+          ],
+          fileIds: [],
+          files: [],
+          replyId: null,
+          renoteId: null
+        }
+        const megalodonStatus = MisskeyAPI.Converter.note(note)
+        expect(megalodonStatus.emojis).toEqual([
+          {
+            shortcode: ':example1:',
+            static_url: 'https://example.com/emoji1.png',
+            url: 'https://example.com/emoji1.png',
+            visible_in_picker: true,
+            category: ''
+          },
+          {
+            shortcode: ':example2:',
+            static_url: 'https://example.com/emoji2.png',
+            url: 'https://example.com/emoji2.png',
+            visible_in_picker: true,
+            category: ''
+          }
+        ])
+      })
+      it('emojis in object format should be parsed', () => {
+        const plainContent = 'hoge\nfuga\nfuga'
+        const note: MisskeyEntity.Note = {
+          id: '1',
+          createdAt: '2021-02-01T01:49:29',
+          userId: '1',
+          user: user,
+          text: plainContent,
+          cw: null,
+          visibility: 'public',
+          renoteCount: 0,
+          repliesCount: 0,
+          reactions: {},
+          reactionEmojis: {},
+          emojis: {
+            ':example1:': 'https://example.com/emoji1.png',
+            ':example2:': 'https://example.com/emoji2.png',
+          },
+          fileIds: [],
+          files: [],
+          replyId: null,
+          renoteId: null
+        }
+        const megalodonStatus = MisskeyAPI.Converter.note(note)
+        expect(megalodonStatus.emojis).toEqual([
+          {
+            shortcode: ':example1:',
+            static_url: 'https://example.com/emoji1.png',
+            url: 'https://example.com/emoji1.png',
+            visible_in_picker: true,
+            category: ''
+          },
+          {
+            shortcode: ':example2:',
+            static_url: 'https://example.com/emoji2.png',
+            url: 'https://example.com/emoji2.png',
+            visible_in_picker: true,
+            category: ''
+          }
+        ])
+      })
+    })
   })
 })


### PR DESCRIPTION
I noticed that while Megalodon assumes that Misskey emojis come down in an array, in my testing, they have the same format as the `reactionEmojis`: that is to say, an object of key (shortcode) value (url) pairs. This change uses the same logic as for mapping emoji reactions to generate the emojis list. 

I don't know if older versions of Misskey presented the `emojis` field as an array, so I've kept in the old logic for backwards compatibility. Both instances I tested on (misskey.io and misskey.design) exhibited the new behavior. 

```
curl -d '{"i": $MISSKEY_ACCESS_KEY }' -H "Content-Type: application/json" -X POST https://misskey.design/api/notes/timeline

[
    {
        "id": "9hcg3rd24h",
        "createdAt": "2023-07-18T22:43:39.974Z",
        "userId": "9ccl3jbs6i",
        "user": {
            "id": "9ccl3jbs6i",
            "name": "望月ハル:skeb::verified_blue:",
            "username": "haltaro3",
            "host": "misskey.io",
            "avatarUrl": "https://misskey.design/proxy/avatar.webp?url=https%3A%2F%2Ffile.misskey.design%2Fpost%2F393a162a-61bb-46ed-b889-15d026be0e83.png&avatar=1",
            "avatarBlurhash": "ePQJAuRiI:D%.7~qs:smxuRQo}bIt7xuMx?Ht7WBspSzD*ayt6axxa",
            "isBot": false,
            "isCat": false,
            "instance": {
                "name": "Misskey.io",
                "softwareName": "misskey",
                "softwareVersion": "13.13.2",
                "iconUrl": "https://misskey.io/static-assets/icons/192.png",
                "faviconUrl": "https://s3.arkjp.net/misskey/webpublic-0c66b1ca-b8c0-4eaa-9827-47674f4a1580.png",
                "themeColor": "#86b300"
            },
            "emojis": {
                "skeb": "https://s3.arkjp.net/misskey/03e01164-c5f3-42e4-9c70-1619fef7f076.png",
                "verified_blue": "https://s3.arkjp.net/emoji/verified_blue.png"
            },
            "onlineStatus": "unknown"
        },
        "text": "ダンボールの山減らす作業しなきゃ:blobcozynap:",
        "cw": null,
        "visibility": "public",
        "localOnly": false,
        "reactionAcceptance": null,
        "renoteCount": 0,
        "repliesCount": 0,
        "reactions": {
            ":blobhai@misskey.io:": 1,
            ":super_igyo@misskey.io:": 9
        },
        "reactionEmojis": {
            "blobhai@misskey.io": "https://s3.arkjp.net/emoji/blobhai.gif",
            "super_igyo@misskey.io": "https://s3.arkjp.net/misskey/4ad1e9a6-9744-4a92-89bf-fac1ad3e7a65.png"
        },
        "emojis": {
            "blobcozynap": "https://s3.arkjp.net/emoji/blobcozynap.png"
        },
        "fileIds": [],
        "files": [],
        "replyId": null,
        "renoteId": null,
        "uri": "https://misskey.io/notes/9hcg3rd2uu"
    },
...
]
```

The `emojis` field is not mentioned at all in the [API docs](https://misskey.design/api-doc#tag/notes/operation/notes/local-timeline), so I don't have a source of truth other than my test requests. 
