### PR TITLE
Fix #1828: urlToAccounts returns converted data

### DIFF
--- a/megalodon/src/mastodon.ts
+++ b/megalodon/src/mastodon.ts
@@ -571,7 +571,7 @@ export default class Mastodon implements MegalodonInterface {
         }
       }
     }
-    return res
+    return converted
   }
 
   /**


### PR DESCRIPTION
Looks like the regression happened in https://github.com/h3poteto/megalodon/commit/fe7c66ee64514df0be5ff39a8743525e7d1297ae#diff-bc08808ad598b8a873b55b7fe24d4bd6b4159f3228b5f4ffc947bf3bbeca0604R572 here, note how we build `converted` but never return it 😭. The `friendica.ts` has the correct return, just not Mastodon 😅

---

Tested as follows (I may have skipped a step here, sorry, let me know and I'll elaborate this): first check out this branch of `megalodon` and build it via:
```console
npm i --force
npm run build -w megalodon
```
(There's some weird version issue when run `npm i`, something about eslint being unsatisfied, so I use `--force` to skip this…)

Then make a test app and install this modified `megalodon`:
```console
mkdir megalodon-test
cd megalodon-test
npm init -y
npm i typescript
npx tsc --init
npm i -S /path/to/megalodon
```
and in here create `index.ts`:
```ts
import generator, { Entity, Response } from "megalodon";
const BASE_URL = "https://octodon.social";
const access_token = "...";
const client = generator("mastodon", BASE_URL, access_token);
client.getAccountFollowers("45008", { get_all: true }).then((res) => {
  console.log(res.data.length);
});
```
and build this and run it:
```console
npx tsc -p .
node index.js
```
Should print out a number >40. (`45008` is me on Octodon, so you'll have to change this probably.)