### PR TITLE
Update browser example to support nodejs polyfill

### DIFF
--- a/example/browser/package.json
+++ b/example/browser/package.json
@@ -19,6 +19,7 @@
     "http-server": "^14.1.1",
     "https-browserify": "^1.0.0",
     "os-browserify": "^0.3.0",
+    "process": "^0.11.10",
     "querystring-es3": "^0.2.1",
     "stream-browserify": "^3.0.0",
     "stream-http": "^3.2.0",

--- a/example/browser/webpack.config.js
+++ b/example/browser/webpack.config.js
@@ -40,6 +40,10 @@ module.exports = {
     new webpack.DefinePlugin({
       'process.browser': true,
       'process.env.NODE_DEBUG': false
+    }),
+    new webpack.ProvidePlugin({
+      Buffer: ['buffer', 'Buffer'],
+      process: 'process/browser'
     })
   ]
   // https-proxy-agent and socks-proxy-agent is node library, so can't compile for browser.


### PR DESCRIPTION
Hi.
I tried to use this library in a browser environment, referring to the [example/browse](https://github.com/h3poteto/megalodon/tree/master/example/browser)r directory. However, I noticed that errors occur due to the absence of polyfills for 'process' and 'Buffer'.

I have updated the webpack configuration and the package.json to apply the necessary polyfills. (like [node-polyfill-webpack-plugin](https://github.com/Richienb/node-polyfill-webpack-plugin))
