### PR TITLE
fix: prevent reference error

### DIFF
--- a/megalodon/src/mastodon.ts
+++ b/megalodon/src/mastodon.ts
@@ -1588,7 +1588,7 @@ export default class Mastodon implements MegalodonInterface {
         })
       }
     }
-    if (options.scheduled_at) {
+    if (options && options.scheduled_at) {
       return this.client.post<MastodonAPI.Entity.ScheduledStatus>('/api/v1/statuses', params).then(res => {
         return Object.assign(res, {
           data: MastodonAPI.Converter.scheduled_status(res.data)

--- a/megalodon/src/pleroma.ts
+++ b/megalodon/src/pleroma.ts
@@ -1575,7 +1575,7 @@ export default class Pleroma implements MegalodonInterface {
         })
       }
     }
-    if (options.scheduled_at) {
+    if (options && options.scheduled_at) {
       return this.client.post<PleromaAPI.Entity.ScheduledStatus>('/api/v1/statuses', params).then(res => {
         return Object.assign(res, {
           data: PleromaAPI.Converter.scheduled_status(res.data)


### PR DESCRIPTION
the below fix is for an issue that occurs straight when following the tutorial to post a new comment on mastodon. it could be done cleaner considering the options object already being checked above but as this block contains a return statement i did not feel to break the flow of the code