### PR TITLE
refactor: :loud_sound: Clearer NotImplementedError messages

### DIFF
--- a/megalodon/src/firefish.ts
+++ b/megalodon/src/firefish.ts
@@ -5,7 +5,7 @@ import { ProxyConfig } from './proxy_config'
 import OAuth from './oauth'
 import * as FirefishOAuth from './firefish/oauth'
 import Response from './response'
-import { MegalodonInterface, WebSocketInterface, NoImplementedError, ArgumentError, UnexpectedError } from './megalodon'
+import { MegalodonInterface, WebSocketInterface, NotImplementedError, ArgumentError, UnexpectedError } from './megalodon'
 import { UnknownNotificationTypeError } from './notification'
 
 export default class Firefish implements MegalodonInterface {
@@ -120,7 +120,7 @@ export default class Firefish implements MegalodonInterface {
   // ======================================
   public async verifyAppCredentials(): Promise<Response<Entity.Application>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -154,14 +154,14 @@ export default class Firefish implements MegalodonInterface {
 
   public async refreshToken(_client_id: string, _client_secret: string, _refresh_token: string): Promise<OAuth.TokenData> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async revokeToken(_client_id: string, _client_secret: string, _token: string): Promise<Response<Record<never, never>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -178,7 +178,7 @@ export default class Firefish implements MegalodonInterface {
     _reason?: string | null
   ): Promise<Response<Entity.Token>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -349,21 +349,21 @@ export default class Firefish implements MegalodonInterface {
     }
   ): Promise<Response<Array<Entity.Status>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async subscribeAccount(_id: string): Promise<Response<Entity.Relationship>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async unsubscribeAccount(_id: string): Promise<Response<Entity.Relationship>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -426,14 +426,14 @@ export default class Firefish implements MegalodonInterface {
 
   public async getAccountLists(_id: string): Promise<Response<Array<Entity.List>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async getIdentityProof(_id: string): Promise<Response<Array<Entity.IdentityProof>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -548,14 +548,14 @@ export default class Firefish implements MegalodonInterface {
 
   public async pinAccount(_id: string): Promise<Response<Entity.Relationship>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async unpinAccount(_id: string): Promise<Response<Entity.Relationship>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -635,7 +635,7 @@ export default class Firefish implements MegalodonInterface {
     min_id?: string
   }): Promise<Response<Array<Entity.Status>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -741,21 +741,21 @@ export default class Firefish implements MegalodonInterface {
   // ======================================
   public async getDomainBlocks(_options?: { limit?: number; max_id?: string; min_id?: string }): Promise<Response<Array<string>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async blockDomain(_domain: string): Promise<Response<Record<never, never>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async unblockDomain(_domain: string): Promise<Response<Record<never, never>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -765,14 +765,14 @@ export default class Firefish implements MegalodonInterface {
   // ======================================
   public async getFilters(): Promise<Response<Array<Entity.Filter>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async getFilter(_id: string): Promise<Response<Entity.Filter>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -787,7 +787,7 @@ export default class Firefish implements MegalodonInterface {
     }
   ): Promise<Response<Entity.Filter>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -803,14 +803,14 @@ export default class Firefish implements MegalodonInterface {
     }
   ): Promise<Response<Entity.Filter>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async deleteFilter(_id: string): Promise<Response<Entity.Filter>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -912,7 +912,7 @@ export default class Firefish implements MegalodonInterface {
     since_id?: string
   }): Promise<Response<Array<Entity.Account>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -922,28 +922,28 @@ export default class Firefish implements MegalodonInterface {
   // ======================================
   public async getFeaturedTags(): Promise<Response<Array<Entity.FeaturedTag>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async createFeaturedTag(_name: string): Promise<Response<Entity.FeaturedTag>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async deleteFeaturedTag(_id: string): Promise<Response<Record<never, never>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async getSuggestedTags(): Promise<Response<Array<Entity.Tag>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -953,7 +953,7 @@ export default class Firefish implements MegalodonInterface {
   // ======================================
   public async getPreferences(): Promise<Response<Entity.Preferences>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -963,7 +963,7 @@ export default class Firefish implements MegalodonInterface {
   // ======================================
   public async getFollowedTags(): Promise<Response<Array<Entity.Tag>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -991,21 +991,21 @@ export default class Firefish implements MegalodonInterface {
   // ======================================
   public async getTag(_id: string): Promise<Response<Entity.Tag>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async followTag(_id: string): Promise<Response<Entity.Tag>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async unfollowTag(_id: string): Promise<Response<Entity.Tag>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -1105,7 +1105,7 @@ export default class Firefish implements MegalodonInterface {
     }
   ): Promise<Response<Entity.Status>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -1160,7 +1160,7 @@ export default class Firefish implements MegalodonInterface {
 
   public async getStatusSource(_id: string): Promise<Response<Entity.StatusSource>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -1181,7 +1181,7 @@ export default class Firefish implements MegalodonInterface {
 
   public async getStatusFavouritedBy(_id: string): Promise<Response<Array<Entity.Account>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -1241,28 +1241,28 @@ export default class Firefish implements MegalodonInterface {
 
   public async bookmarkStatus(_id: string): Promise<Response<Entity.Status>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async unbookmarkStatus(_id: string): Promise<Response<Entity.Status>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async muteStatus(_id: string): Promise<Response<Entity.Status>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async unmuteStatus(_id: string): Promise<Response<Entity.Status>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -1363,7 +1363,7 @@ export default class Firefish implements MegalodonInterface {
   // ======================================
   public async getPoll(_id: string): Promise<Response<Entity.Poll>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -1410,28 +1410,28 @@ export default class Firefish implements MegalodonInterface {
     min_id?: string
   }): Promise<Response<Array<Entity.ScheduledStatus>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async getScheduledStatus(_id: string): Promise<Response<Entity.ScheduledStatus>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async scheduleStatus(_id: string, _scheduled_at?: string | null): Promise<Response<Entity.ScheduledStatus>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async cancelScheduledStatus(_id: string): Promise<Response<Record<never, never>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -1701,14 +1701,14 @@ export default class Firefish implements MegalodonInterface {
 
   public async deleteConversation(_id: string): Promise<Response<Record<never, never>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async readConversation(_id: string): Promise<Response<Entity.Conversation>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -1816,7 +1816,7 @@ export default class Firefish implements MegalodonInterface {
   // ======================================
   public async getMarkers(_timeline: Array<string>): Promise<Response<Entity.Marker | Record<never, never>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -1826,7 +1826,7 @@ export default class Firefish implements MegalodonInterface {
     notifications?: { last_read_id: string }
   }): Promise<Response<Entity.Marker>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -1887,7 +1887,7 @@ export default class Firefish implements MegalodonInterface {
 
   public async getNotification(_id: string): Promise<Response<Entity.Notification>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -1901,7 +1901,7 @@ export default class Firefish implements MegalodonInterface {
 
   public async dismissNotification(_id: string): Promise<Response<Record<never, never>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -1911,7 +1911,7 @@ export default class Firefish implements MegalodonInterface {
     max_id?: string
   }): Promise<Response<Entity.Notification | Array<Entity.Notification>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('mastodon does not support')
+      const err = new NotImplementedError('mastodon does not support')
       reject(err)
     })
   }
@@ -1924,14 +1924,14 @@ export default class Firefish implements MegalodonInterface {
     _data?: { alerts: { follow?: boolean; favourite?: boolean; reblog?: boolean; mention?: boolean; poll?: boolean } } | null
   ): Promise<Response<Entity.PushSubscription>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async getPushSubscription(): Promise<Response<Entity.PushSubscription>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -1940,7 +1940,7 @@ export default class Firefish implements MegalodonInterface {
     _data?: { alerts: { follow?: boolean; favourite?: boolean; reblog?: boolean; mention?: boolean; poll?: boolean } } | null
   ): Promise<Response<Entity.PushSubscription>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -1950,7 +1950,7 @@ export default class Firefish implements MegalodonInterface {
    */
   public async deletePushSubscription(): Promise<Response<Record<never, never>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -2201,14 +2201,14 @@ export default class Firefish implements MegalodonInterface {
 
   public async getInstancePeers(): Promise<Response<Array<string>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async getInstanceActivity(): Promise<Response<Array<Entity.Activity>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -2235,7 +2235,7 @@ export default class Firefish implements MegalodonInterface {
     local?: boolean
   }): Promise<Response<Array<Entity.Account>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -2268,21 +2268,21 @@ export default class Firefish implements MegalodonInterface {
 
   public async dismissInstanceAnnouncement(_id: string): Promise<Response<Record<never, never>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async addReactionToAnnouncement(_id: string, _name: string): Promise<Response<Record<never, never>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
 
   public async removeReactionFromAnnouncement(_id: string, _name: string): Promise<Response<Record<never, never>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -2336,7 +2336,7 @@ export default class Firefish implements MegalodonInterface {
 
   public async getEmojiReaction(_id: string, _emoji: string): Promise<Response<Entity.Reaction>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('firefish does not support')
+      const err = new NotImplementedError('Firefish does not support this method')
       reject(err)
     })
   }
@@ -2354,7 +2354,7 @@ export default class Firefish implements MegalodonInterface {
   }
 
   public tagSocket(_tag: string): WebSocketInterface {
-    throw new NoImplementedError('TODO: implement')
+    throw new NotImplementedError('TODO: implement')
   }
 
   public listSocket(list_id: string): WebSocketInterface {

--- a/megalodon/src/friendica.ts
+++ b/megalodon/src/friendica.ts
@@ -4,7 +4,7 @@ import parseLinkHeader from 'parse-link-header'
 
 import FriendicaAPI from './friendica/api_client'
 import WebSocket from './friendica/web_socket'
-import { MegalodonInterface, NoImplementedError } from './megalodon'
+import { MegalodonInterface, NotImplementedError } from './megalodon'
 import Response from './response'
 import Entity from './entity'
 import { NO_REDIRECT, DEFAULT_SCOPE, DEFAULT_UA } from './default'
@@ -217,7 +217,7 @@ export default class Friendica implements MegalodonInterface {
     _reason?: string | null
   ): Promise<Response<Entity.Token>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
@@ -251,7 +251,7 @@ export default class Friendica implements MegalodonInterface {
     fields_attributes?: Array<{ name: string; value: string }>
   }): Promise<Response<Entity.Account>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
@@ -392,7 +392,7 @@ export default class Friendica implements MegalodonInterface {
     }
   ): Promise<Response<Array<Entity.Status>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
@@ -633,7 +633,7 @@ export default class Friendica implements MegalodonInterface {
    */
   public async pinAccount(_id: string): Promise<Response<Entity.Relationship>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
@@ -646,7 +646,7 @@ export default class Friendica implements MegalodonInterface {
    */
   public async unpinAccount(_id: string): Promise<Response<Entity.Relationship>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
@@ -905,21 +905,21 @@ export default class Friendica implements MegalodonInterface {
   // ======================================
   public async getDomainBlocks(_options?: { limit?: number; max_id?: string; min_id?: string }): Promise<Response<Array<string>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
 
   public blockDomain(_domain: string): Promise<Response<Record<string, unknown>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
 
   public unblockDomain(_domain: string): Promise<Response<Record<string, unknown>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
@@ -942,7 +942,7 @@ export default class Friendica implements MegalodonInterface {
 
   public async getFilter(_id: string): Promise<Response<Entity.Filter>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
@@ -957,7 +957,7 @@ export default class Friendica implements MegalodonInterface {
     }
   ): Promise<Response<Entity.Filter>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
@@ -973,14 +973,14 @@ export default class Friendica implements MegalodonInterface {
     }
   ): Promise<Response<Entity.Filter>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
 
   public async deleteFilter(_id: string): Promise<Response<Entity.Filter>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
@@ -999,7 +999,7 @@ export default class Friendica implements MegalodonInterface {
     }
   ): Promise<Response<Entity.Report>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
@@ -1103,28 +1103,28 @@ export default class Friendica implements MegalodonInterface {
   // ======================================
   public async getFeaturedTags(): Promise<Response<Array<Entity.FeaturedTag>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
 
   public async createFeaturedTag(_name: string): Promise<Response<Entity.FeaturedTag>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
 
   public deleteFeaturedTag(_id: string): Promise<Response<Record<string, unknown>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
 
   public async getSuggestedTags(): Promise<Response<Array<Entity.Tag>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
@@ -1150,7 +1150,7 @@ export default class Friendica implements MegalodonInterface {
   // ======================================
   public async getFollowedTags(): Promise<Response<Array<Entity.Tag>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
@@ -1756,7 +1756,7 @@ export default class Friendica implements MegalodonInterface {
 
   public async votePoll(_id: string, _choices: Array<number>): Promise<Response<Entity.Poll>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
@@ -1825,7 +1825,7 @@ export default class Friendica implements MegalodonInterface {
 
   public async scheduleStatus(_id: string, _scheduled_at?: string | null): Promise<Response<Entity.ScheduledStatus>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
@@ -2460,7 +2460,7 @@ export default class Friendica implements MegalodonInterface {
     max_id?: string
   }): Promise<Response<Entity.Notification | Array<Entity.Notification>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
@@ -2778,7 +2778,7 @@ export default class Friendica implements MegalodonInterface {
    */
   public async dismissInstanceAnnouncement(_id: string): Promise<Response<Record<never, never>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
@@ -2791,7 +2791,7 @@ export default class Friendica implements MegalodonInterface {
    */
   public async addReactionToAnnouncement(_id: string, _name: string): Promise<Response<Record<never, never>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
@@ -2804,7 +2804,7 @@ export default class Friendica implements MegalodonInterface {
    */
   public async removeReactionFromAnnouncement(_id: string, _name: string): Promise<Response<Record<never, never>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
@@ -2814,28 +2814,28 @@ export default class Friendica implements MegalodonInterface {
   // ======================================
   public async createEmojiReaction(_id: string, _emoji: string): Promise<Response<Entity.Status>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
 
   public async deleteEmojiReaction(_id: string, _emoji: string): Promise<Response<Entity.Status>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
 
   public async getEmojiReactions(_id: string): Promise<Response<Array<Entity.Reaction>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }
 
   public async getEmojiReaction(_id: string, _emoji: string): Promise<Response<Entity.Reaction>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('friendica does not support')
+      const err = new NotImplementedError('Friendica does not support this method')
       reject(err)
     })
   }

--- a/megalodon/src/mastodon.ts
+++ b/megalodon/src/mastodon.ts
@@ -4,7 +4,7 @@ import parseLinkHeader from 'parse-link-header'
 
 import MastodonAPI from './mastodon/api_client'
 import Streaming from './mastodon/web_socket'
-import { MegalodonInterface, NoImplementedError } from './megalodon'
+import { MegalodonInterface, NotImplementedError } from './megalodon'
 import Response from './response'
 import Entity from './entity'
 import { NO_REDIRECT, DEFAULT_SCOPE, DEFAULT_UA } from './default'
@@ -434,7 +434,7 @@ export default class Mastodon implements MegalodonInterface {
     }
   ): Promise<Response<Array<Entity.Status>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('mastodon does not support')
+      const err = new NotImplementedError('Mastodon does not support this method')
       reject(err)
     })
   }
@@ -2773,7 +2773,7 @@ export default class Mastodon implements MegalodonInterface {
     max_id?: string
   }): Promise<Response<Entity.Notification | Array<Entity.Notification>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('mastodon does not support')
+      const err = new NotImplementedError('Mastodon does not support this method')
       reject(err)
     })
   }
@@ -3115,28 +3115,28 @@ export default class Mastodon implements MegalodonInterface {
   // ======================================
   public async createEmojiReaction(_id: string, _emoji: string): Promise<Response<Entity.Status>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('mastodon does not support')
+      const err = new NotImplementedError('Mastodon does not support this method')
       reject(err)
     })
   }
 
   public async deleteEmojiReaction(_id: string, _emoji: string): Promise<Response<Entity.Status>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('mastodon does not support')
+      const err = new NotImplementedError('Mastodon does not support this method')
       reject(err)
     })
   }
 
   public async getEmojiReactions(_id: string): Promise<Response<Array<Entity.Reaction>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('mastodon does not support')
+      const err = new NotImplementedError('Mastodon does not support this method')
       reject(err)
     })
   }
 
   public async getEmojiReaction(_id: string, _emoji: string): Promise<Response<Entity.Reaction>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('mastodon does not support')
+      const err = new NotImplementedError('Mastodon does not support this method')
       reject(err)
     })
   }

--- a/megalodon/src/megalodon.ts
+++ b/megalodon/src/megalodon.ts
@@ -1378,7 +1378,7 @@ export interface MegalodonInterface {
   directSocket(): WebSocketInterface
 }
 
-export class NoImplementedError extends Error {
+export class NotImplementedError extends Error {
   constructor(err?: string) {
     super(err)
 

--- a/megalodon/src/pleroma.ts
+++ b/megalodon/src/pleroma.ts
@@ -3,7 +3,7 @@ import FormData from 'form-data'
 
 import PleromaAPI from './pleroma/api_client'
 import WebSocket from './pleroma/web_socket'
-import { MegalodonInterface, NoImplementedError, ArgumentError } from './megalodon'
+import { MegalodonInterface, NotImplementedError, ArgumentError } from './megalodon'
 import Response from './response'
 import Entity from './entity'
 import { NO_REDIRECT, DEFAULT_SCOPE, DEFAULT_UA } from './default'
@@ -1404,7 +1404,7 @@ export default class Pleroma implements MegalodonInterface {
   // ======================================
   public async getFollowedTags(): Promise<Response<Array<Entity.Tag>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('pleroma does not support')
+      const err = new NotImplementedError('Pleroma does not support this method')
       reject(err)
     })
   }
@@ -1449,7 +1449,7 @@ export default class Pleroma implements MegalodonInterface {
    */
   public async getTag(_id: string): Promise<Response<Entity.Tag>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('pleroma does not support')
+      const err = new NotImplementedError('Pleroma does not support this method')
       reject(err)
     })
   }
@@ -1462,7 +1462,7 @@ export default class Pleroma implements MegalodonInterface {
    */
   public async followTag(_id: string): Promise<Response<Entity.Tag>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('pleroma does not support')
+      const err = new NotImplementedError('Pleroma does not support this method')
       reject(err)
     })
   }
@@ -1475,7 +1475,7 @@ export default class Pleroma implements MegalodonInterface {
    */
   public async unfollowTag(_id: string): Promise<Response<Entity.Tag>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('pleroma does not support')
+      const err = new NotImplementedError('Pleroma does not support this method')
       reject(err)
     })
   }
@@ -3113,7 +3113,7 @@ export default class Pleroma implements MegalodonInterface {
    */
   public async addReactionToAnnouncement(_id: string, _name: string): Promise<Response<Record<never, never>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('pleroma does not support')
+      const err = new NotImplementedError('Pleroma does not support this method')
       reject(err)
     })
   }
@@ -3126,7 +3126,7 @@ export default class Pleroma implements MegalodonInterface {
    */
   public async removeReactionFromAnnouncement(_id: string, _name: string): Promise<Response<Record<never, never>>> {
     return new Promise((_, reject) => {
-      const err = new NoImplementedError('pleroma does not support')
+      const err = new NotImplementedError('Pleroma does not support this method')
       reject(err)
     })
   }


### PR DESCRIPTION
Errors that are formatted like `firefish does not support` are now formatted like `Firefish does not support this method`, and the `NoImplementedError` error type has been renamed to `NotImplementedError` (given it's *not* implemented, not *no* implemented)