### PR TITLE
Fix typescript in dependencies

### DIFF
--- a/megalodon/package.json
+++ b/megalodon/package.json
@@ -52,28 +52,27 @@
   },
   "homepage": "https://github.com/h3poteto/megalodon#readme",
   "dependencies": {
-    "@types/oauth": "^0.9.2",
-    "@types/ws": "^8.5.5",
     "axios": "1.5.1",
     "dayjs": "^1.11.10",
     "form-data": "^4.0.0",
     "https-proxy-agent": "^7.0.2",
+    "isomorphic-ws": "^5.0.0",
     "oauth": "^0.10.0",
     "object-assign-deep": "^0.4.0",
     "parse-link-header": "^2.0.0",
     "socks-proxy-agent": "^8.0.2",
-    "typescript": "5.2.2",
     "uuid": "^9.0.1",
-    "ws": "8.14.2",
-    "isomorphic-ws": "^5.0.0"
+    "ws": "8.14.2"
   },
   "devDependencies": {
     "@types/core-js": "^2.5.6",
     "@types/form-data": "^2.5.0",
     "@types/jest": "^29.5.5",
+    "@types/oauth": "^0.9.2",
     "@types/object-assign-deep": "^0.4.1",
     "@types/parse-link-header": "^2.0.1",
     "@types/uuid": "^9.0.4",
+    "@types/ws": "^8.5.6",
     "@typescript-eslint/eslint-plugin": "^6.7.4",
     "@typescript-eslint/parser": "^6.7.4",
     "eslint": "^8.49.0",
@@ -84,6 +83,7 @@
     "lodash": "^4.17.14",
     "prettier": "^3.0.3",
     "ts-jest": "^29.1.1",
-    "typedoc": "^0.25.1"
+    "typedoc": "^0.25.1",
+    "typescript": "^5.2.2"
   }
 }


### PR DESCRIPTION
There are several dependencies which should be in devDependencies section: typescript, @types/ws, and @types/oauth.

PR fixes this issue (#1972).