### PR TITLE
Add file directive to package.json

### DIFF
--- a/megalodon/package.json
+++ b/megalodon/package.json
@@ -13,6 +13,9 @@
   "engines": {
     "node": ">=15.0.0"
   },
+  "files": [
+      "/lib/src/**"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/h3poteto/megalodon.git"


### PR DESCRIPTION
This commit adds file directive to `package.json` to reduce the published package size and include only required files. It's always better to use this directive over `.npmignore`, because it's less prone to bloat package with unnecessary files, especially in the case of having huge files or security keys in a project.

As a result the package size should be reduced from 1.6 Mb to 0.83 Mb.

After this PR `megalodon/.npmignore` will become obsolete and could be removed. 