### PR TITLE
Use getPreferences instead of getDefaultPostVisibility

### DIFF
--- a/megalodon/src/firefish.ts
+++ b/megalodon/src/firefish.ts
@@ -960,7 +960,7 @@ export default class Firefish implements MegalodonInterface {
     })
   }
 
-  public async getDefaultPostPrivacy(): Promise<Entity.Preferences['posting:default:visibility']> {
+  private async getDefaultPostPrivacy(): Promise<Entity.Preferences['posting:default:visibility']> {
     return this.client
       .post<string>('/api/i/registry/get-unsecure', {
         key: 'defaultNoteVisibility',

--- a/megalodon/src/friendica.ts
+++ b/megalodon/src/friendica.ts
@@ -1145,13 +1145,6 @@ export default class Friendica implements MegalodonInterface {
     })
   }
 
-  public async getDefaultPostPrivacy(): Promise<Entity.Preferences['posting:default:visibility']> {
-    return new Promise((_, reject) => {
-      const err = new NotImplementedError('Friendica does not support this method')
-      reject(err)
-    })
-  }
-
   // ======================================
   // accounts/followed_tags
   // ======================================

--- a/megalodon/src/mastodon.ts
+++ b/megalodon/src/mastodon.ts
@@ -1403,13 +1403,6 @@ export default class Mastodon implements MegalodonInterface {
     })
   }
 
-  public async getDefaultPostPrivacy(): Promise<Entity.Preferences['posting:default:visibility']> {
-    return new Promise((_, reject) => {
-      const err = new NotImplementedError('Mastodon does not support this method')
-      reject(err)
-    })
-  }
-
   // ======================================
   // accounts/followed_tags
   // ======================================

--- a/megalodon/src/megalodon.ts
+++ b/megalodon/src/megalodon.ts
@@ -602,12 +602,6 @@ export interface MegalodonInterface {
    */
   getPreferences(): Promise<Response<Entity.Preferences>>
 
-  /**
-   * Get the default post privacy defined by the user in their account settings. Firefish only.
-   *
-   * @return Preferences.
-   */
-  getDefaultPostPrivacy(): Promise<Entity.Preferences['posting:default:visibility']>
   // ======================================
   // accounts/followed_tags
   // ======================================

--- a/megalodon/src/pleroma.ts
+++ b/megalodon/src/pleroma.ts
@@ -1400,13 +1400,6 @@ export default class Pleroma implements MegalodonInterface {
     })
   }
 
-  public async getDefaultPostPrivacy(): Promise<Entity.Preferences['posting:default:visibility']> {
-    return new Promise((_, reject) => {
-      const err = new NotImplementedError('Pleroma does not support this method')
-      reject(err)
-    })
-  }
-
   // ======================================
   // accounts/followed_tags
   // ======================================


### PR DESCRIPTION
I don't understand why `getDefaultPostVisibility` is required. `getPreferences` is enough.
Refs: https://github.com/h3poteto/megalodon/pull/1959