### PR TITLE
Move typescript to devDependencies

### DIFF
--- a/megalodon/package.json
+++ b/megalodon/package.json
@@ -65,7 +65,6 @@
     "object-assign-deep": "^0.4.0",
     "parse-link-header": "^2.0.0",
     "socks-proxy-agent": "^8.0.2",
-    "typescript": "5.2.2",
     "uuid": "^9.0.1",
     "ws": "8.14.2",
     "isomorphic-ws": "^5.0.0"
@@ -87,6 +86,7 @@
     "lodash": "^4.17.14",
     "prettier": "^3.0.3",
     "ts-jest": "^29.1.1",
-    "typedoc": "^0.25.1"
+    "typedoc": "^0.25.1",
+    "typescript": "^5.2.2"
   }
 }

--- a/megalodon/package.json
+++ b/megalodon/package.json
@@ -87,6 +87,6 @@
     "prettier": "^3.0.3",
     "ts-jest": "^29.1.1",
     "typedoc": "^0.25.1",
-    "typescript": "^5.2.2"
+    "typescript": "5.2.2"
   }
 }


### PR DESCRIPTION
This commit fixes (#1971) moves typescript to devDependencies without affecting types (#1990).