### PR TITLE
Fix file directive for dual package

### DIFF
--- a/megalodon/package.json
+++ b/megalodon/package.json
@@ -15,7 +15,8 @@
     "node": ">=15.0.0"
   },
   "files": [
-    "/lib/src/**"
+    "/lib/src/**",
+    "/lib/esm/**"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
```
$ ls megalodon/lib  
esm  src  test
```

For dual package support, we need to push `lib/src` and `lib/esm`.