### PR TITLE
Add events package for browser

### DIFF
--- a/megalodon/package.json
+++ b/megalodon/package.json
@@ -67,7 +67,8 @@
     "object-assign-deep": "^0.4.0",
     "uuid": "^9.0.1",
     "ws": "8.14.2",
-    "isomorphic-ws": "^5.0.0"
+    "isomorphic-ws": "^5.0.0",
+    "events": "^3.3.0"
   },
   "devDependencies": {
     "@types/core-js": "^2.5.6",


### PR DESCRIPTION
Otherwise, we got an error 
```
Module "events" has been externalized for browser compatibility. Cannot access "events.EventEmitter" in client code. 
```