### PR TITLE
Fix argument on websocket error event

### DIFF
--- a/megalodon/src/firefish/web_socket.ts
+++ b/megalodon/src/firefish/web_socket.ts
@@ -282,7 +282,7 @@ export default class WebSocket extends EventEmitter implements WebSocketInterfac
       this.parser.parse(event, this._channelID)
     }
     client.onerror = event => {
-      this.emit('error', event.target)
+      this.emit('error', event.error)
     }
     if (!isBrowser()) {
       client.on('pong', () => {

--- a/megalodon/src/mastodon/web_socket.ts
+++ b/megalodon/src/mastodon/web_socket.ts
@@ -211,7 +211,7 @@ export default class Streaming extends EventEmitter implements WebSocketInterfac
       this.parser.parse(event)
     }
     client.onerror = event => {
-      this.emit('error', event.target)
+      this.emit('error', event.error)
     }
 
     if (!isBrowser()) {

--- a/megalodon/src/pleroma/web_socket.ts
+++ b/megalodon/src/pleroma/web_socket.ts
@@ -213,7 +213,7 @@ export default class WebSocket extends EventEmitter implements WebSocketInterfac
       this.parser.parse(event)
     }
     client.onerror = event => {
-      this.emit('error', event.target)
+      this.emit('error', event.error)
     }
 
     if (!isBrowser()) {


### PR DESCRIPTION
Expected behavior for stream error event is the error instance in the argument. Actual behavior is we get a `WebSocket` instance there and no error info.

This change fixes it.