### PR TITLE
Mastodon: Fix the trailing slash in the WebSocket URI

### DIFF
--- a/megalodon/src/mastodon/web_socket.ts
+++ b/megalodon/src/mastodon/web_socket.ts
@@ -152,7 +152,7 @@ export default class Streaming extends EventEmitter implements WebSocketInterfac
     if (accessToken !== null) {
       parameter.push(`access_token=${accessToken}`)
     }
-    const requestURL: string = `${url}/?${parameter.join('&')}`
+    const requestURL: string = `${url}?${parameter.join('&')}`
     if (isBrowser()) {
       // This is browser.
       // We can't pass options when browser: https://github.com/heineiuo/isomorphic-ws#limitations


### PR DESCRIPTION
Remove the trailing slash in the Mastodon streaming URI to match the [documentation](https://docs.joinmastodon.org/methods/streaming/#websocket).

Mastodon works in both cases (with and without the trailing slash). This change would fix connecting to GoToSocial that follows the documented Mastodon API more strictly.

More info on the problem here: https://github.com/superseriousbusiness/gotosocial/issues/2704 