### PR TITLE
feat: add another option to GoToSocial API

### DIFF
--- a/megalodon/src/gotosocial.ts
+++ b/megalodon/src/gotosocial.ts
@@ -356,6 +356,7 @@ export default class Gotosocial implements MegalodonInterface {
    * @param options.exclude_replies Return statuses which exclude replies.
    * @param options.exclude_reblogs Return statuses which exclude reblogs.
    * @param options.only_media Show only statuses with media attached? Defaults to false.
+   * @param options.only_public Return statuses with public visibility only.
    * @return Account's statuses.
    */
   public async getAccountStatuses(
@@ -369,6 +370,7 @@ export default class Gotosocial implements MegalodonInterface {
       exclude_replies?: boolean
       exclude_reblogs?: boolean
       only_media: boolean
+      only_public?: boolean
     }
   ): Promise<Response<Array<Entity.Status>>> {
     let params = {}
@@ -411,6 +413,11 @@ export default class Gotosocial implements MegalodonInterface {
       if (options.only_media) {
         params = Object.assign(params, {
           only_media: options.only_media
+        })
+      }
+      if (options.only_public) {
+        params = Object.assign(params, {
+          only_public: options.only_public
         })
       }
     }

--- a/megalodon/src/megalodon.ts
+++ b/megalodon/src/megalodon.ts
@@ -169,6 +169,7 @@ export interface MegalodonInterface {
    * @param options.exclude_replies Return statuses which exclude replies.
    * @param options.exclude_reblogs Return statuses which exclude reblogs.
    * @param options.only_media Show only statuses with media attached? Defaults to false.
+   * @param options.only_public Return statuses with public visibility only.
    * @return Account's statuses.
    */
   getAccountStatuses(
@@ -182,6 +183,7 @@ export interface MegalodonInterface {
       exclude_replies?: boolean
       exclude_reblogs?: boolean
       only_media?: boolean
+      only_public?: boolean
     }
   ): Promise<Response<Array<Entity.Status>>>
   /**


### PR DESCRIPTION
This supports a documented API option to GET only public statuses, thereby potentially reducing the bandwidth size.

Fixes #2210 