### PR TITLE
GoToSocial: fix `getAccountFollowing` failing because the final page omits a `link` header.

### DIFF
--- a/megalodon/src/gotosocial.ts
+++ b/megalodon/src/gotosocial.ts
@@ -569,6 +569,9 @@ export default class Gotosocial implements MegalodonInterface {
         converted = Object.assign({}, converted, {
           data: [...converted.data, ...nextRes.data.map(a => GotosocialAPI.Converter.account(a))]
         })
+        if (nextRes.headers.link === undefined){
+          break;
+        }
         parsed = parseLinkHeader(nextRes.headers.link)
         if (sleep_ms) {
           await new Promise<void>(converted => setTimeout(converted, sleep_ms))


### PR DESCRIPTION
`urlToAccounts()` appears to assume that the `link` header will continue to be present, but in my testing when I call `getAccountFollowing()`, the final page of accounts is completely missing the `link` header.
`parseLinkHeader()` throws if you pass an `undefined` header into it, so without this fix I'm effectively unable to use `getAccountFollowing()` on my GoToSocial instance.