### PR TITLE
Add remote flag to pixelfed public timeline

### DIFF
--- a/megalodon/src/pixelfed.ts
+++ b/megalodon/src/pixelfed.ts
@@ -2154,7 +2154,8 @@ export default class Pixelfed implements MegalodonInterface {
     min_id?: string
   }): Promise<Response<Array<Entity.Status>>> {
     let params = {
-      local: false
+      local: false,
+      remote: true
     }
     if (options) {
       if (options.only_media !== undefined) {


### PR DESCRIPTION
In Pixelfed, if `remote: false`, remote posts are not included in the public timeline.