### PR TITLE
fix #1596: Add content-type field to pleroma and gotosocial backends

### DIFF
--- a/megalodon/src/gotosocial.ts
+++ b/megalodon/src/gotosocial.ts
@@ -1342,6 +1342,7 @@ export default class Gotosocial implements MegalodonInterface {
    * @param options.scheduled_at ISO 8601 Datetime at which to schedule a status.
    * @param options.language ISO 639 language code for this status.
    * @param options.quote_id ID of the status being quoted to, if status is a quote.
+   * @param options.content_type Content type to use when parsing this status.
    * @return Status. When options.scheduled_at is present, ScheduledStatus is returned instead.
    */
   public async postStatus(
@@ -1356,6 +1357,7 @@ export default class Gotosocial implements MegalodonInterface {
       scheduled_at?: string
       language?: string
       quote_id?: string
+      content_type?: string
     }
   ): Promise<Response<Entity.Status | Entity.ScheduledStatus>> {
     let params = {
@@ -1416,6 +1418,11 @@ export default class Gotosocial implements MegalodonInterface {
       if (options.language) {
         params = Object.assign(params, {
           language: options.language
+        })
+      }
+      if (options.content_type) {
+        params = Object.assign(params, {
+          content_type: options.content_type
         })
       }
     }

--- a/megalodon/src/pleroma.ts
+++ b/megalodon/src/pleroma.ts
@@ -1521,6 +1521,7 @@ export default class Pleroma implements MegalodonInterface {
    * @param options.scheduled_at ISO 8601 Datetime at which to schedule a status.
    * @param options.language ISO 639 language code for this status.
    * @param options.quote_id ID of the status being quoted to, if status is a quote.
+   * @param options.content_type Content type to use when parsing this status.
    * @return Status. When options.scheduled_at is present, ScheduledStatus is returned instead.
    */
   public async postStatus(
@@ -1535,6 +1536,7 @@ export default class Pleroma implements MegalodonInterface {
       scheduled_at?: string
       language?: string
       quote_id?: string
+      content_type?: string
     }
   ): Promise<Response<Entity.Status | Entity.ScheduledStatus>> {
     let params = {
@@ -1598,6 +1600,11 @@ export default class Pleroma implements MegalodonInterface {
       if (options.quote_id) {
         params = Object.assign(params, {
           quote_id: options.quote_id
+        })
+      }
+      if (options.content_type) {
+        params = Object.assign(params, {
+          content_type: options.content_type
         })
       }
     }


### PR DESCRIPTION
Hi! I'm adding this feature specifically to use with Akkoma, but I looked through each api. only akkoma is tested, and we don't do any amount of static checking on the input (pleroma derivatives communicate what valid content-types there are through nodeinfo, so the valid set of inputs is dynamic)

pleroma docs:
https://docs-develop.pleroma.social/backend/development/API/differences_in_mastoapi_responses/#post-apiv1statuses
akkoma docs:
https://docs.akkoma.dev/stable/development/API/differences_in_mastoapi_responses/#post-apiv1statuses
gotosocial docs:
https://docs.gotosocial.org/en/latest/api/swagger
scroll to
/api/v1/statuses

vanilla masto and friendica don't support this, firefish appears to be discontinued, and I can't find documentation for pixelfed?
